### PR TITLE
PropTypes to import from prop-types package to remove deprecation war…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-images-uploader",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React.js component for uploading images to the server",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-polyfill": "^6.20.0",
     "classnames": "^2.2.5",
     "isomorphic-fetch": "^2.2.1",
+    "prop-types": "^15.5.8",
     "react": "^15.4.1",
     "react-addons-test-utils": "^15.4.1",
     "react-css-modules": "^4.0.3",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,6 @@
 /* @flow */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import fetch from 'isomorphic-fetch';
 import autobind from 'autobind-decorator';
 import classnames from 'classnames';


### PR DESCRIPTION
I have moved the PropTypes import to pull from the 'prop-types' package to remove console deprecation warnings, and improve compatibility with future react versions. I have also incremented the version to 1.1.1 to signal a minor change.