### PR TITLE
Fix SSR document undefined problem

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -114,6 +114,7 @@ export default class ImagesUploader extends Component {
 	/* eslint-enable react/sort-comp */
 
 	componentWillMount() {
+		if(typeof document === 'undefined') return;
 		document.addEventListener('dragover', (event) => {
 			// prevent default to allow drop
 			event.preventDefault();

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -114,15 +114,19 @@ export default class ImagesUploader extends Component {
 	/* eslint-enable react/sort-comp */
 
 	componentWillMount() {
-		if(typeof document === 'undefined') return;
-		document.addEventListener('dragover', (event) => {
-			// prevent default to allow drop
-			event.preventDefault();
-		}, false);
-		document.addEventListener('drop', (event) => {
-			// prevent default to allow drop
-			event.preventDefault();
-		}, false);
+		// support SSR rendering.
+		// we should not use document on server, so just omit
+		// these calls
+		if (typeof document !== 'undefined') {
+			document.addEventListener('dragover', event => {
+				// prevent default to allow drop
+				event.preventDefault();
+			}, false);
+			document.addEventListener('drop', event => {
+				// prevent default to allow drop
+				event.preventDefault();
+			}, false);
+		}
 	}
 
 	componentWillReceiveProps(nextProps: Object) {


### PR DESCRIPTION
On first load in a Server Side Rendered app `componentWillMount` runs twice one on server and one on client . the first load throws 
``` 
ReferenceError: document is not defined
 at ImagesUploader.componentWillMount (...\node_modules\react-images-uploader\lib\index.js:132:4)
```